### PR TITLE
Fix bug on toggling menu burger

### DIFF
--- a/js/modernweb2017.js
+++ b/js/modernweb2017.js
@@ -146,6 +146,9 @@ var modernweb2017 = new Vue({
                 // mobile
                 $(".menu__burger, .menu__mask").on('click', function () {
                     $(this).toggleClass("on");
+                    if (this.className.indexOf('menu__mask') !== -1) {
+                        $('.menu__burger').toggleClass("on");
+                    }
                     $('.menu__content').toggleClass("on");
                     $(".menu").toggleClass('on');
                     $('body').toggleClass('is-hidden');


### PR DESCRIPTION
Hi,
I spotted a minor UI bug when using mobile as client.
The burger button won't toggle when the menu is closed by clicking/tapping out side of the menu panel.
This PR should fix it.